### PR TITLE
a collection of minor fixes to address warnings

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -1,0 +1,2 @@
+cwmsr.Rproj
+^LICENSE\.md$

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -5,8 +5,7 @@ Authors@R:
     person("Norman", "Buccola", , "norman.buccola@usace.army.mil", role = c("aut", "cre"),
            comment = c(ORCID = "YOUR-ORCID-ID"))
 Description: Function to get CWMS data from the USACE CWMS Data Service API. Create full URLs from path names, dates, timezone, and office.
-License: `use_mit_license()`, `use_gpl3_license()` or friends to pick a
-    license
+License: MIT + file LICENSE
 Encoding: UTF-8
 Roxygen: list(markdown = TRUE)
 RoxygenNote: 7.3.2

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,2 @@
+YEAR: 2025
+COPYRIGHT HOLDER: cwmsr authors

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,21 @@
+# MIT License
+
+Copyright (c) 2025 cwmsr authors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/NAMESPACE
+++ b/NAMESPACE
@@ -3,5 +3,8 @@
 export(cwms_to_dt)
 export(get_cwms)
 export(get_url)
+importFrom(foreach,"%do%")
 importFrom(foreach,foreach)
 importFrom(jsonlite,fromJSON)
+importFrom(utils,URLencode)
+importFrom(utils,download.file)

--- a/R/cwms_read.r
+++ b/R/cwms_read.r
@@ -11,11 +11,20 @@
 #' @author Norman Buccola
 #' @keywords CWMS Corps USACE data retrieval
 #' @examples
+#' \dontrun{
+#' beginDate <- strptime('2024-08-01',"%Y-%m-%d",tz = 'PST8PDT')
+#' endDate <- strptime('2024-12-31',"%Y-%m-%d",tz = 'PST8PDT')
+#' CWMSpaths <- 'DET.Elev-Forebay.Inst.0.0.Best'
+#' get_cwms(CWMSpaths, beginDate, endDate)
+#' }
 #' @export
-#' @importFrom foreach foreach
+#' @importFrom foreach foreach %do%
 get_cwms<-function(paths, start_date, end_date, timezone = 'PST8PDT',
                    timeseries=T,
                    CDApath = 'https://wm.nww.ds.usace.army.mil:8243/nwdp-data/'){
+
+  # shortcut to avoid R CMD Check warning
+  y <- NULL
   date_diff <- end_date - start_date
   parse_length <- 90 #days
   if(date_diff > parse_length){

--- a/R/cwms_to_dt.r
+++ b/R/cwms_to_dt.r
@@ -12,8 +12,13 @@
 #' @author Norman Buccola
 #' @keywords CWMS Corps USACE data retrieval
 #' @examples
+#' \dontrun{
+#' cwms_to_dt('DET.Elev-Forebay.Inst.0.0.Best', '2024-08-01', '2024-12-31',
+#'   "PST8PDT", timeseries = TRUE)
+#' }
 #' @export
 #' @importFrom jsonlite fromJSON
+#' @importFrom utils download.file
 cwms_to_dt<-function(path, start_date, end_date, timezone = timezone,
                      timeseries,CDApath = CDApath,linux=F){
   url = get_url(path, start_date, end_date, timezone = timezone,timeseries)

--- a/R/get_url.r
+++ b/R/get_url.r
@@ -11,6 +11,10 @@
 #' @author Norman Buccola
 #' @keywords CWMS Corps USACE data retrieval
 #' @examples
+#' \dontrun{
+#' get_url('DET.Elev-Forebay.Inst.0.0.Best', '2024-08-01', '2024-12-31')
+#' }
+#' @importFrom utils URLencode
 #' @export
 get_url<-function(path, start_date, end_date, timezone = 'PST8PDT',
                   timeseries=T,

--- a/inst/cwms_read_r_demo.r
+++ b/inst/cwms_read_r_demo.r
@@ -1,10 +1,10 @@
+# install from github
+# remotes::install_github("nbuccola/cwmsr")
+
 # Demonstrate cwms_read_CDA.r usage
-rm(list = ls())
-library(devtools)
-install_github("nbuccola/cwmsr")
-install.packages('cwmsr')
 library(cwmsr)
-LocalWd <- 'C:/Users/g2echnb9/OneDrive - US Army Corps of Engineers/Desktop'
+
+LocalWd <- tempdir()
 CDApath <- 'https://wm.nww.ds.usace.army.mil:8243/nwdp-data/'
 # Setup input variables
 beginDate <- strptime('2024-01-01',"%Y-%m-%d",tz = 'PST8PDT')
@@ -21,6 +21,7 @@ x24 <- get_cwms(CWMSpaths,start_date=beginDate,end_date=endDate,
 
 library(dplyr)
 library(tidyr)
+library(ggplot2)
 cwmsPivot_longer <- function(x){
   x |> 
     tidyr::pivot_longer(-Date) |>

--- a/man/cwms_to_dt.Rd
+++ b/man/cwms_to_dt.Rd
@@ -37,6 +37,12 @@ a data.frame of the data
 Function to get CWMS data from one path on the USACE CDA
 Written by NBuccola on 2025-01-21 based on Jetilton; taken from https://github.com/jetilton/cwms_read/blob/master/cwms_read.r
 }
+\examples{
+\dontrun{
+cwms_to_dt('DET.Elev-Forebay.Inst.0.0.Best', '2024-08-01', '2024-12-31',
+  "PST8PDT", timeseries = TRUE)
+}
+}
 \author{
 Norman Buccola
 }

--- a/man/get_cwms.Rd
+++ b/man/get_cwms.Rd
@@ -34,6 +34,14 @@ a data.frame of the data
 Wrapper function to get CWMS data from the USACE CDA
 Written by NBuccola on 2025-01-21 based on Jetilton; taken from https://github.com/jetilton/cwms_read/blob/master/cwms_read.r
 }
+\examples{
+\dontrun{
+beginDate <- strptime('2024-08-01',"\%Y-\%m-\%d",tz = 'PST8PDT')
+endDate <- strptime('2024-12-31',"\%Y-\%m-\%d",tz = 'PST8PDT')
+CWMSpaths <- 'DET.Elev-Forebay.Inst.0.0.Best'
+get_cwms(CWMSpaths, beginDate, endDate)
+}
+}
 \author{
 Norman Buccola
 }

--- a/man/get_url.Rd
+++ b/man/get_url.Rd
@@ -34,6 +34,11 @@ a data.frame of the data
 Function to create full URL for cwms_get.r
 Written by NBuccola on 2025-01-21 based on Jetilton; taken from https://github.com/jetilton/cwms_read/blob/master/cwms_read.r
 }
+\examples{
+\dontrun{
+get_url('DET.Elev-Forebay.Inst.0.0.Best', '2024-08-01', '2024-12-31')
+}
+}
 \author{
 Norman Buccola
 }


### PR DESCRIPTION
Address warnings from `devtools::check()`:

- add .Rbuildignore to ignore Rstudio project file on package build
- add license
- add missing imports to Roxygen docs
- add missing examples to roxygen docs